### PR TITLE
Add inclusion of string.h to build successful

### DIFF
--- a/poddl.hpp
+++ b/poddl.hpp
@@ -25,6 +25,7 @@
 #else
 #include <unistd.h>
 #include <dirent.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <curl/curl.h>
 #endif


### PR DESCRIPTION
The application was not buildable both with gcc (version 12) and clang (version 15). That is now fixed.