### PR TITLE
Add "-a" command to append episode number

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ How to use:
 Optional arguments:  
 -o = Output path (needed if arguments are passed)  
 -l = Only display list of episodes  
--s = Use episode numbers as file names (nnn.ext)  
+-s = Use episode numbers as file names (nnn.ext)
+-a = Append episode number to beginning of file names
 -r = Download/List newest episodes first  
 -n N = Download a single episode  
 -n N-N = Download a range of episodes  

--- a/helper.cpp
+++ b/helper.cpp
@@ -92,6 +92,7 @@ void Helper::print_options(const Options &options)
     std::cout << "path: " << options.path << std::endl;
     std::cout << "list_only: " << options.list_only << std::endl;
     std::cout << "short_names: " << options.short_names << std::endl;
+    std::cout << "append_nums: " << options.append_nums << std::endl;
     std::cout << "newest_first: " << options.newest_first << std::endl;
     std::cout << "episode_from: " << options.episode_from << std::endl;
     std::cout << "episode_to: " << options.episode_to << std::endl;

--- a/helper.cpp
+++ b/helper.cpp
@@ -127,6 +127,9 @@ Options Helper::get_options(const std::vector<std::string> &args) {
         else if (arg == "-s") {
             options.short_names = true;
         }
+        else if (arg == "-a") {
+            options.append_nums = true;
+        }
         else if (arg == "-r") {
             options.newest_first = true;
         } 

--- a/main.cpp
+++ b/main.cpp
@@ -45,6 +45,7 @@ void print_help() {
     std::cout << "-o = Output path (needed if arguments are passed)" << std::endl;
     std::cout << "-l = Only display list of episodes" << std::endl;
     std::cout << "-s = Use episode numbers as file names (nnn.ext)" << std::endl;
+    std::cout << "-a = Append episode number to beginning of file names" << std::endl;
     std::cout << "-r = Download/List newest episodes first" << std::endl;
     std::cout << "-n N = Download a single episode" << std::endl;
     std::cout << "-n N-N = Download a range of episodes" << std::endl;
@@ -72,6 +73,7 @@ int main(int argc, const char *argv[]) {
      *  -n 1    Download episode 1	
      *  -n 1-3  Download episode 1-3
      *  -s      Use episode number as file name (nnn.ext)
+     *  -a      Append episode number to beginning of file names
      *  -r      Download latest episodes first
      *  -h      Quit program if file exists
      *  -h abc  Quit program if episode name contains "abc"
@@ -164,6 +166,10 @@ int main(int argc, const char *argv[]) {
         }
 
         auto title = item.title;
+
+        if (options.append_nums) {
+            title = "[" + std::to_string(item.number) + "] " + title;
+        }
 
         if (options.short_names) {
             title = std::to_string(item.number);

--- a/poddl.hpp
+++ b/poddl.hpp
@@ -74,6 +74,7 @@ struct Podcast {
 struct Options {
     bool list_only = false;
     bool short_names = false;
+    bool append_nums = false;
     bool newest_first = false;
     bool stop_when_file_found = false;
     int episode_from = -1;


### PR DESCRIPTION
Couldn't get it to build on my PC due to curl issues - not sure what the fix is. But I wanted to add an option to add the episode number to the title, without removing the title itself (like what the "-s" command does). That way, it can be easily sorted in a list while still knowing what the episode title is.