### PR TITLE
Zero-pad numbers in filenames

### DIFF
--- a/helper.cpp
+++ b/helper.cpp
@@ -24,6 +24,8 @@
 
 #include "poddl.hpp"
 #include "html_coder.hpp"
+#include <iostream>
+#include <iomanip>
 
 /*
     / \ * ? | <> : "
@@ -83,6 +85,13 @@ int int_try_parse(std::string text) {
     }
 
     return 0;
+}
+
+std::string Helper::zero_pad(const int value, const unsigned total_len)
+{
+     std::ostringstream oss;
+     oss << std::setw(total_len) << std::setfill('0') << value;
+     return oss.str();
 }
 
 void Helper::debug_print_options(const Options &options) 

--- a/main.cpp
+++ b/main.cpp
@@ -155,11 +155,12 @@ int main(int argc, const char *argv[]) {
         }
 
         auto title = item.title;
-
+        
+        std::string number_str = Helper::zero_pad(item.number, std::to_string(size).length());
         if (options.short_names) {
-            title = std::to_string(item.number);
+            title = number_str;
         } else if (options.append_episode_nr) {
-            title = std::to_string(item.number) + ". " + item.title;
+            title = number_str + ". " + item.title;
         }
 
 #ifdef _WIN32

--- a/poddl.hpp
+++ b/poddl.hpp
@@ -98,6 +98,7 @@ public:
     static std::string clean_filename(std::string input);
     static std::string url_encode_lazy(std::string input);
     static std::string get_extension(std::string input);
+    static std::string zero_pad(int value, const unsigned total_len);
 #ifdef _WIN32
     static std::wstring utf8_to_wide_win_string(std::string input);
     static std::string wide_win_string_to_utf8(std::wstring input);
@@ -138,3 +139,4 @@ public:
     static bool get_string_stream(std::string url, std::ostringstream &output_stream);
     static bool write_file_stream(std::string url, std::ofstream &output_stream);
 };
+


### PR DESCRIPTION
Some players order files by name. Zero padding will make sure that the sorting is correct.