### PR TITLE
Accept attributes on item element

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -29,7 +29,7 @@ std::string const enclosure_pattern = "<enclosure.*?url=[\"|'](.+?)[\"|'].*?>";
 std::string const title_pattern = "<title>(.+?)</title>";
 std::string const cdata_pattern = "<\\!\\[CDATA\\[(.+?)\\]\\]>";
 
-std::string const start_tag = "<item>";
+std::string const start_tag = "<item";
 std::string const end_tag = "</item>";
 std::size_t const end_len = end_tag.length();
 


### PR DESCRIPTION
`<item>` elements can contain attributes, for example(from a podcast on acast):
```
<item locked="false" tier="1234567" ads="false" spons="false" premium="true">
```

It's a quick dirty fix for this case, maybe a regex with `<item(>|[ \t].*>)` would be more accurate but I don't think it's necessary(afaik there is no other element in the spec that start with item).